### PR TITLE
Compute fair value line from weighted APY

### DIFF
--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -11,7 +11,7 @@ import {
 import { useTranslation } from 'react-i18next';
 
 export interface ChartData {
-    time: string;
+    time: number;
     ytPrice: number | null;
     points: number | null;
     fairValue: number;
@@ -35,17 +35,8 @@ export function Chart({ data, marketName, underlyingAmount, chainName }: ChartPr
         );
     }
 
-    // Format data for Recharts and sort by time
-    const sortedData = data
-        .map((item) => ({
-            time: new Date(item.time).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }),
-            ytPrice: item.ytPrice,
-            points: item.points,
-            fairValue: item.fairValue
-        }))
-        .sort((a, b) => new Date(a.time).getTime() - new Date(b.time).getTime());
-
-    const chartData = sortedData;
+    // Sort data by timestamp to ensure proper ordering
+    const chartData = [...data].sort((a, b) => a.time - b.time);
 
     return (
         <div className="w-full bg-card card-elevated rounded-lg p-6">
@@ -58,11 +49,20 @@ export function Chart({ data, marketName, underlyingAmount, chainName }: ChartPr
                     <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
                     
                     {/* X Axis - Time */}
-                    <XAxis 
-                        dataKey="time" 
+                    <XAxis
+                        dataKey="time"
+                        type="number"
+                        domain={['dataMin', 'dataMax']}
                         stroke="#888888"
                         fontSize={12}
                         tick={{ fill: '#888888' }}
+                        tickFormatter={(value) => new Date(value).toLocaleString('en-US', {
+                            month: 'short',
+                            day: 'numeric',
+                            hour: '2-digit',
+                            minute: '2-digit',
+                            second: '2-digit'
+                        })}
                     />
                     
                     {/* Left Y Axis - YT Price */}


### PR DESCRIPTION
## Summary
- Use volume-weighted implied APY from all transactions to compute a fair value curve sampled from now to maturity
- Switch chart to numeric timestamps for full precision and extend the fair value line through maturity

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: existing lint errors)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b14b69c22c832eb6bbe95f2013342f