### PR TITLE
Compute fair value line from weighted APY

### DIFF
--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -11,7 +11,7 @@ import {
 import { useTranslation } from 'react-i18next';
 
 export interface ChartData {
-    time: string;
+    time: number;
     ytPrice: number | null;
     points: number | null;
     fairValue: number;
@@ -22,9 +22,10 @@ interface ChartProps {
     marketName: string;
     underlyingAmount: number;
     chainName: string;
+    maturityDate?: Date;
 }
 
-export function Chart({ data, marketName, underlyingAmount, chainName }: ChartProps) {
+export function Chart({ data, marketName, underlyingAmount, chainName, maturityDate }: ChartProps) {
     const { t } = useTranslation();
     
     if (!data || data.length === 0) {
@@ -35,22 +36,13 @@ export function Chart({ data, marketName, underlyingAmount, chainName }: ChartPr
         );
     }
 
-    // Format data for Recharts and sort by time
-    const sortedData = data
-        .map((item) => ({
-            time: new Date(item.time).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }),
-            ytPrice: item.ytPrice,
-            points: item.points,
-            fairValue: item.fairValue
-        }))
-        .sort((a, b) => new Date(a.time).getTime() - new Date(b.time).getTime());
-
-    const chartData = sortedData;
+    // Sort data by timestamp to ensure proper ordering
+    const chartData = [...data].sort((a, b) => a.time - b.time);
 
     return (
         <div className="w-full bg-card card-elevated rounded-lg p-6">
             <h3 className="text-lg font-semibold text-center mb-6 text-foreground">
-                {marketName} on {chainName} [{underlyingAmount} {t('chart.underlyingCoin')}]
+                {marketName} on {chainName} [{underlyingAmount} {t('chart.underlyingCoin')}] {maturityDate ? `- ${t('chart.maturity')} ${maturityDate.toLocaleString()}` : ''}
             </h3>
             
             <ResponsiveContainer width="100%" height={400}>
@@ -58,11 +50,20 @@ export function Chart({ data, marketName, underlyingAmount, chainName }: ChartPr
                     <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
                     
                     {/* X Axis - Time */}
-                    <XAxis 
-                        dataKey="time" 
+                    <XAxis
+                        dataKey="time"
+                        type="number"
+                        domain={['dataMin', 'dataMax']}
                         stroke="#888888"
                         fontSize={12}
                         tick={{ fill: '#888888' }}
+                        tickFormatter={(value) => new Date(value).toLocaleString('en-US', {
+                            month: 'short',
+                            day: 'numeric',
+                            hour: '2-digit',
+                            minute: '2-digit',
+                            second: '2-digit'
+                        })}
                     />
                     
                     {/* Left Y Axis - YT Price */}

--- a/src/components/MarketSelect.tsx
+++ b/src/components/MarketSelect.tsx
@@ -43,7 +43,7 @@ function formatExpiryTime(expiry: string): string {
         } else {
             return `${dateStr} (Expired)`
         }
-    } catch (error) {
+    } catch {
         return expiry // Return original string if parsing fails
     }
 }
@@ -71,7 +71,7 @@ export function MarketSelect(props: {selectedChain: string, selectedMarket: Mark
             console.error("Failed to fetch markets:", error)
             setIsLoading(false)
         })
-    }, [selectedChain]) // Add selectedMarket back to dependencies
+    }, [selectedChain, setSelectedMarket]) // Add selectedMarket back to dependencies
 
     const selectedMarketData = markets.find(market => market.address === selectedMarket?.address)
 
@@ -83,7 +83,7 @@ export function MarketSelect(props: {selectedChain: string, selectedMarket: Mark
     )
 
     return (
-        <div className="w-78">
+        <div className="w-full sm:w-78">
             <Popover open={open} onOpenChange={setOpen}>
                 <PopoverTrigger asChild>
                     <Button

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -17,7 +17,8 @@
     "pointsEarned": "Points earned if bought at this time until maturity",
     "fairValueCurve": "Fair Value Curve of YT",
     "underlyingCoin": "underlying coin",
-    "maximizePointsHint": "Buy when YT price is below the fair value curve to maximize points"
+    "maximizePointsHint": "Buy when YT price is below the fair value curve to maximize points",
+    "maturity": "Maturity:"
   },
   "main": {
     "chain": "Chain",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -17,7 +17,8 @@
     "pointsEarned": "从现在购买到到期可获得的积分",
     "fairValueCurve": "YT 公平价值曲线",
     "underlyingCoin": "底层代币",
-    "maximizePointsHint": "在 YT 价格低于公平价值曲线时购买以最大化积分"
+    "maximizePointsHint": "在 YT 价格低于公平价值曲线时购买以最大化积分",
+    "maturity": "到期时间："
   },
   "main": {
     "chain": "链",


### PR DESCRIPTION
## Summary
- Calculate current points available using weighted implied APY to populate the points block
- Display market maturity time in chart title via new translation key
- Enhance mobile responsiveness with full-width inputs and a responsive market selector

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: unexpected any and other existing lint errors)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b14b69c22c832eb6bbe95f2013342f