### PR TITLE
Use flex sizing for inputs

### DIFF
--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -126,7 +126,7 @@ export function From() {
                 <div className='flex flex-col space-y-2 flex-1 min-w-[8rem]'>
                     <label className='text-sm font-medium text-muted-foreground whitespace-nowrap'>{t('main.chain')}</label>
                     <Select value={selectedChain} onValueChange={handleChainChange}>
-                        <SelectTrigger className="w-full sm:w-48 input-enhanced">
+                        <SelectTrigger className="w-full input-enhanced">
                             <SelectValue placeholder={t('main.selectChain')} />
                         </SelectTrigger>
                         <SelectContent>
@@ -150,7 +150,7 @@ export function From() {
                         value={underlyingAmount}
                         onChange={(e) => setUnderlyingAmount(Number(e.target.value))}
                         placeholder="1500"
-                        className="w-full sm:w-40 input-enhanced"
+                        className="w-full input-enhanced"
                         min="0"
                     />
                 </div>
@@ -161,7 +161,7 @@ export function From() {
                         value={pointsPerDay}
                         onChange={(e) => setPointsPerDay(Number(e.target.value))}
                         placeholder="1"
-                        className="w-full sm:w-40 input-enhanced"
+                        className="w-full input-enhanced"
                         min="0"
                     />
                 </div>
@@ -172,7 +172,7 @@ export function From() {
                         value={pendleMultiplier}
                         onChange={(e) => setPendleMultiplier(Number(e.target.value))}
                         placeholder="36"
-                        className="w-full sm:w-40 input-enhanced"
+                        className="w-full input-enhanced"
                         min="0"
                     />
                 </div>

--- a/src/components/MarketSelect.tsx
+++ b/src/components/MarketSelect.tsx
@@ -83,7 +83,7 @@ export function MarketSelect(props: {selectedChain: string, selectedMarket: Mark
     )
 
     return (
-        <div className="w-full sm:w-78">
+        <div className="w-full flex-1 sm:max-w-xs">
             <Popover open={open} onOpenChange={setOpen}>
                 <PopoverTrigger asChild>
                     <Button


### PR DESCRIPTION
## Summary
- Replace fixed width in `MarketSelect` with flex-grow and responsive max width
- Remove fixed small-screen widths in `Main` inputs to rely on `flex-1`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 10 errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68b15b9eb83c832e9400819a17e3b0eb