### PR TITLE
Fix market name overflow in selector

### DIFF
--- a/src/components/MarketSelect.tsx
+++ b/src/components/MarketSelect.tsx
@@ -97,8 +97,10 @@ export function MarketSelect(props: {selectedChain: string, selectedMarket: Mark
                             ? t('marketSelect.loadingMarkets')
                             : selectedMarketData 
                                 ? <div className="flex items-center justify-between w-full">
-                                    <span className="font-medium">{selectedMarketData.name}</span>
-                                    <span className="text-xs text-muted-foreground ml-2">
+                                    <div className="flex-1 min-w-0">
+                                        <span className="font-medium truncate">{selectedMarketData.name}</span>
+                                    </div>
+                                    <span className="text-xs text-muted-foreground ml-2 whitespace-nowrap">
                                         {formatExpiryTime(selectedMarketData.expiry)}
                                     </span>
                                 </div>


### PR DESCRIPTION
## Summary
- prevent selected market name from expanding market selector by truncating long names
- keep expiry text visible with no-wrap formatting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 10 errors)*
- `npx eslint src/components/MarketSelect.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b15bd74370832e923fc34e45120c5a