### PR TITLE
Use latest points value and label chart axes

### DIFF
--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -26,7 +26,7 @@ interface ChartProps {
 }
 
 export function Chart({ data, marketName, underlyingAmount, chainName, maturityDate }: ChartProps) {
-    const { t } = useTranslation();
+    const { t, i18n } = useTranslation();
     
     if (!data || data.length === 0) {
         return (
@@ -46,7 +46,7 @@ export function Chart({ data, marketName, underlyingAmount, chainName, maturityD
             </h3>
             
             <ResponsiveContainer width="100%" height={400}>
-                <LineChart data={chartData} margin={{ top: 20, right: 30, left: 20, bottom: 20 }}>
+                <LineChart key={i18n.language} data={chartData} margin={{ top: 20, right: 30, left: 20, bottom: 20 }}>
                     <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
                     
                     {/* X Axis - Time */}
@@ -67,7 +67,7 @@ export function Chart({ data, marketName, underlyingAmount, chainName, maturityD
                     />
                     
                     {/* Left Y Axis - YT Price */}
-                    <YAxis 
+                    <YAxis
                         yAxisId="left"
                         orientation="left"
                         stroke="#888888"
@@ -75,10 +75,11 @@ export function Chart({ data, marketName, underlyingAmount, chainName, maturityD
                         tick={{ fill: '#888888' }}
                         domain={[0, 'dataMax + 0.01']}
                         tickFormatter={(value) => value.toFixed(4)}
+                        label={{ value: t('chart.yAxisLeft'), angle: -90, position: 'insideLeft', fill: '#888888' }}
                     />
-                    
+
                     {/* Right Y Axis - Points */}
-                    <YAxis 
+                    <YAxis
                         yAxisId="right"
                         orientation="right"
                         stroke="#888888"
@@ -93,6 +94,7 @@ export function Chart({ data, marketName, underlyingAmount, chainName, maturityD
                             }
                             return value.toString();
                         }}
+                        label={{ value: t('chart.yAxisRight'), angle: -90, position: 'insideRight', fill: '#888888' }}
                     />
                     
                     <Tooltip 
@@ -104,7 +106,7 @@ export function Chart({ data, marketName, underlyingAmount, chainName, maturityD
                         }}
                         labelStyle={{ color: '#ffffff' }}
                         formatter={(value: number, name: string) => {
-                            if (name === t('chart.pointsEarned')) {
+                            if (name === t('chart.yAxisRight')) {
                                 if (!isFinite(value)) {
                                     return ['', name];
                                 }
@@ -115,7 +117,7 @@ export function Chart({ data, marketName, underlyingAmount, chainName, maturityD
                                 }
                                 return [value.toString(), name];
                             }
-                            if (name === t('chart.ytPrice') || name === t('chart.fairValueCurve')) {
+                            if (name === t('chart.yAxisLeft') || name === t('chart.fairValueCurve')) {
                                 if (!isFinite(value)) {
                                     return ['', name];
                                 }
@@ -140,7 +142,7 @@ export function Chart({ data, marketName, underlyingAmount, chainName, maturityD
                         stroke="#3b82f6"
                         strokeWidth={1.5}
                         dot={false}
-                        name={t('chart.ytPrice')}
+                        name={t('chart.yAxisLeft')}
                     />
                     
                     {/* Points Line - Orange */}
@@ -151,7 +153,7 @@ export function Chart({ data, marketName, underlyingAmount, chainName, maturityD
                         stroke="#f97316"
                         strokeWidth={1.5}
                         dot={false}
-                        name={t('chart.pointsEarned')}
+                        name={t('chart.yAxisRight')}
                     />
                     
                     {/* Fair Value Curve - Green Dotted */}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,7 +12,7 @@ const Header: React.FC = () => {
   };
 
   return (
-    <header className="border-b">
+    <header className="fixed top-0 left-0 right-0 z-50 border-b bg-background/80 backdrop-blur">
       <div className="container mx-auto px-6 py-4">
         <div className="flex items-center justify-between">
           {/* Left side - Title and badges */}

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -88,12 +88,9 @@ export function From() {
 
             setChartData([...fairCurve, ...txData].sort((a, b) => a.time - b.time));
 
-            // Compute points available if buying now
-            const hoursToMaturityNow = (computedMaturity.getTime() - now.getTime()) / 3600000;
-            const priceNow = 1 - Math.pow(1 + (computedWeightedImplied || 0), -hoursToMaturityNow / 8760);
-            const pph = pointsPerDay / 24;
-            const pointsNow = (1 / priceNow) * hoursToMaturityNow * pph * underlyingAmount * pendleMultiplier;
-            setPointsAvailable(pointsNow);
+            // Use latest points earned value for points available metric
+            const latestPoints = points[points.length - 1];
+            setPointsAvailable(Number.isFinite(latestPoints) ? latestPoints : 0);
 
         } catch (error) {
             console.error('Chart update failed:', error);
@@ -119,11 +116,11 @@ export function From() {
         }
     }, [selectedMarket, updateChart]);
 
-    return (  
-        <div className='space-y-8'>
+    return (
+        <div className='container mx-auto px-4 pt-24 space-y-8'>
             <div className='bg-card card-elevated rounded-lg p-6'>
-                <div className='flex flex-col sm:flex-row items-stretch sm:items-center gap-4 flex-wrap'>
-                <div className='flex flex-col space-y-2 flex-1 min-w-[8rem]'>
+                <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4'>
+                <div className='flex flex-col space-y-2'>
                     <label className='text-sm font-medium text-muted-foreground whitespace-nowrap'>{t('main.chain')}</label>
                     <Select value={selectedChain} onValueChange={handleChainChange}>
                         <SelectTrigger className="w-full input-enhanced">
@@ -139,11 +136,12 @@ export function From() {
                     </Select>
                 </div>
 
-                <div className='flex flex-col space-y-2 flex-1 min-w-[8rem]'>
+                <div className='flex flex-col space-y-2'>
                     <label className='text-sm font-medium text-muted-foreground whitespace-nowrap'>{t('main.market')}</label>
                     <MarketSelect selectedChain={selectedChain} selectedMarket={selectedMarket} setSelectedMarket={setSelectedMarket} />
                 </div>
-                <div className='flex flex-col space-y-2 flex-1 min-w-[8rem]'>
+
+                <div className='flex flex-col space-y-2'>
                     <label className='text-sm font-medium text-muted-foreground whitespace-nowrap'>{t('main.underlyingAmount')}</label>
                     <Input
                         type="number"
@@ -154,7 +152,8 @@ export function From() {
                         min="0"
                     />
                 </div>
-                <div className='flex flex-col space-y-2 flex-1 min-w-[8rem]'>
+
+                <div className='flex flex-col space-y-2'>
                     <label className='text-sm font-medium text-muted-foreground whitespace-nowrap'>{t('main.pointsPerDay')}</label>
                     <Input
                         type="number"
@@ -165,7 +164,8 @@ export function From() {
                         min="0"
                     />
                 </div>
-                <div className='flex flex-col space-y-2 flex-1 min-w-[8rem]'>
+
+                <div className='flex flex-col space-y-2'>
                     <label className='text-sm font-medium text-muted-foreground whitespace-nowrap'>{t('main.pendleMultiplier')}</label>
                     <Input
                         type="number"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -13,8 +13,8 @@
   },
   "chart": {
     "noDataAvailable": "No data available for chart",
-    "ytPrice": "YT Price",
-    "pointsEarned": "Points earned if bought at this time until maturity",
+    "yAxisLeft": "YT Price",
+    "yAxisRight": "Points earned",
     "fairValueCurve": "Fair Value Curve of YT",
     "underlyingCoin": "underlying coin",
     "maximizePointsHint": "Buy when YT price is below the fair value curve to maximize points",
@@ -33,7 +33,7 @@
     "network": "Network:",
     "transactionsUnique": "Transactions (unique)",
     "weightedImpliedAPYVolume": "Weighted Implied APY (Volume-weighted)",
-    "pointsAvailable": "Points (Points available now upon purchase)"
+    "pointsAvailable": "Points earned if bought now until maturity"
   },
   "marketSelect": {
     "loadingMarkets": "Loading markets...",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -13,8 +13,8 @@
   },
   "chart": {
     "noDataAvailable": "暂无图表数据",
-    "ytPrice": "YT 价格",
-    "pointsEarned": "从现在购买到到期可获得的积分",
+    "yAxisLeft": "YT 价格",
+    "yAxisRight": "获得的积分",
     "fairValueCurve": "YT 公平价值曲线",
     "underlyingCoin": "底层代币",
     "maximizePointsHint": "在 YT 价格低于公平价值曲线时购买以最大化积分",
@@ -33,7 +33,7 @@
     "network": "网络:",
     "transactionsUnique": "交易数量 (唯一)",
     "weightedImpliedAPYVolume": "加权隐含年化收益率 (按成交量加权)",
-    "pointsAvailable": "积分 (现在购买可获得的积分)"
+    "pointsAvailable": "从现在购买到到期可获得的积分"
   },
   "marketSelect": {
     "loadingMarkets": "正在加载市场...",


### PR DESCRIPTION
## Summary
- Localize Y-axis labels for chart points and price with language-aware re-rendering
- Update layout with sticky top bar and responsive input grid for a more modern feel
- Clarify points metric wording in both English and Chinese translations

## Testing
- ⚠️ `npm test` (missing script: test)
- ⚠️ `npm run lint` (errors: Unexpected any, react-refresh)
- ✅ `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b16a9a34ec832eb63c31e82aefa11d