### PR TITLE
fix: hyper EVM support and chart formatting

### DIFF
--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -30,7 +30,7 @@ export function Chart({ data, marketName, underlyingAmount, chainName, maturityD
     const { t, i18n } = useTranslation();
     const { width } = useWindowSize();
     const isMobile = width < 640;
-    const chartHeight = isMobile ? Math.min(480, Math.max(320, width * 0.9)) : 400;
+    const chartHeight = isMobile ? Math.min(600, Math.max(360, width * 1.2)) : 400;
     
     if (!data || data.length === 0) {
         return (
@@ -61,7 +61,7 @@ export function Chart({ data, marketName, underlyingAmount, chainName, maturityD
                         stroke="#888888"
                         fontSize={12}
                         tick={{ fill: '#888888' }}
-                        tickFormatter={(value) => new Date(value).toLocaleString('en-US', {
+                        tickFormatter={(value) => new Date(Number(value)).toLocaleString(i18n.language, {
                             month: 'short',
                             day: 'numeric',
                             hour: '2-digit',
@@ -109,7 +109,7 @@ export function Chart({ data, marketName, underlyingAmount, chainName, maturityD
                             color: '#ffffff'
                         }}
                         labelStyle={{ color: '#ffffff' }}
-                        labelFormatter={(value) => new Date(value).toLocaleString()}
+                        labelFormatter={(value) => new Date(Number(value)).toLocaleString(i18n.language)}
                         formatter={(value: number, name: string) => {
                             if (name === t('chart.yAxisRight')) {
                                 if (!isFinite(value)) {

--- a/src/constant/chain.ts
+++ b/src/constant/chain.ts
@@ -42,9 +42,9 @@ export const chains: { [chainId: number]: Chain } = {
         rpcUrl: 'https://mainnet.base.org',
         explorerUrl: 'https://basescan.org',
     },
-    84532: {
+    999: {
         name: 'Hyper EVM',
-        chainId: 84532,
+        chainId: 999,
         rpcUrl: 'https://hyperevm-rpc.com',
         explorerUrl: 'https://hyperevm-explorer.com',
     },


### PR DESCRIPTION
## Summary
- fix Hyper EVM chain ID so network filtering works
- improve chart timestamps and mobile responsiveness

## Testing
- `npm run lint` *(fails: Unexpected any, fast refresh only works when file only exports components)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8592658d4832eb7f07797b7411677