### PR TITLE
Fix volume-weighted implied APY mismatch in chart

### DIFF
--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -287,7 +287,10 @@ export function From() {
             )}
             {volumeDistribution.length > 0 && (
                 <div className="mt-8">
-                    <VolumeDistributionChart data={volumeDistribution} />
+                    <VolumeDistributionChart
+                        data={volumeDistribution}
+                        weightedApy={(weightedImplied || 0) * 100}
+                    />
                 </div>
             )}
         </div>

--- a/src/components/VolumeDistributionChart.tsx
+++ b/src/components/VolumeDistributionChart.tsx
@@ -20,9 +20,10 @@ export interface VolumeDistributionData {
 
 interface VolumeDistributionChartProps {
     data: VolumeDistributionData[];
+    weightedApy?: number; // percentage
 }
 
-export function VolumeDistributionChart({ data }: VolumeDistributionChartProps) {
+export function VolumeDistributionChart({ data, weightedApy }: VolumeDistributionChartProps) {
     const { t } = useTranslation();
     const { width } = useWindowSize();
     const isMobile = width < 640;
@@ -37,9 +38,11 @@ export function VolumeDistributionChart({ data }: VolumeDistributionChartProps) 
     }
 
     const totalVolume = data.reduce((sum, d) => sum + d.volume, 0);
-    const weightedApy = totalVolume
-        ? data.reduce((sum, d) => sum + d.impliedApy * d.volume, 0) / totalVolume
-        : 0;
+    const effectiveWeightedApy = weightedApy !== undefined
+        ? weightedApy
+        : totalVolume
+            ? data.reduce((sum, d) => sum + d.impliedApy * d.volume, 0) / totalVolume
+            : 0;
     const apyValues = data.map((d) => d.impliedApy);
     const minApy = Math.min(...apyValues);
     const maxApy = Math.max(...apyValues);
@@ -127,12 +130,12 @@ export function VolumeDistributionChart({ data }: VolumeDistributionChartProps) 
                         />
                     </Bar>
                     <ReferenceLine
-                        x={weightedApy}
+                        x={effectiveWeightedApy}
                         stroke="#f59e0b"
                         strokeDasharray="3 3"
                         strokeWidth={2}
                         label={{
-                            value: `${t('main.weightedImpliedAPYVolume')}: ${weightedApy.toFixed(2)}%`,
+                            value: `${t('main.weightedImpliedAPYVolume')}: ${effectiveWeightedApy.toFixed(2)}%`,
                             position: 'top',
                             fill: '#f59e0b',
                             fontSize: 12,

--- a/src/components/VolumeDistributionChart.tsx
+++ b/src/components/VolumeDistributionChart.tsx
@@ -10,7 +10,10 @@ import {
     ReferenceLine,
 } from 'recharts';
 import type { ReactNode } from 'react';
+import { useRef } from 'react';
+import { Download } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
 import { useWindowSize } from '../hooks/use-window-size';
 
 export interface VolumeDistributionData {
@@ -28,6 +31,37 @@ export function VolumeDistributionChart({ data, weightedApy }: VolumeDistributio
     const { width } = useWindowSize();
     const isMobile = width < 640;
     const chartHeight = isMobile ? Math.min(300, Math.max(200, width * 0.6)) : 300;
+    const chartRef = useRef<HTMLDivElement>(null);
+
+    const downloadImage = () => {
+        if (!chartRef.current) return;
+        const svg = chartRef.current.querySelector('svg');
+        if (!svg) return;
+        const serializer = new XMLSerializer();
+        const svgData = serializer.serializeToString(svg);
+        const blob = new Blob([svgData], { type: 'image/svg+xml;charset=utf-8' });
+        const url = URL.createObjectURL(blob);
+        const image = new Image();
+        const width = 1280;
+        const height = 720;
+        image.onload = () => {
+            const canvas = document.createElement('canvas');
+            canvas.width = width;
+            canvas.height = height;
+            const ctx = canvas.getContext('2d');
+            if (ctx) {
+                ctx.fillStyle = '#ffffff';
+                ctx.fillRect(0, 0, width, height);
+                ctx.drawImage(image, 0, 0, width, height);
+                const link = document.createElement('a');
+                link.download = 'volume-distribution.png';
+                link.href = canvas.toDataURL('image/png');
+                link.click();
+            }
+            URL.revokeObjectURL(url);
+        };
+        image.src = url;
+    };
 
     if (!data || data.length === 0) {
         return (
@@ -50,11 +84,23 @@ export function VolumeDistributionChart({ data, weightedApy }: VolumeDistributio
 
     return (
         <div className="w-full bg-card card-elevated rounded-lg p-6">
-            <h3 className="text-lg font-semibold text-center mb-6 text-foreground">
-                {t('chart.volumeDistributionTitle')}
-            </h3>
-            <ResponsiveContainer width="100%" height={chartHeight}>
-                <BarChart data={data} margin={{ top: 20, right: 30, left: 20, bottom: 20 }}>
+            <div className="relative mb-6">
+                <h3 className="text-lg font-semibold text-center text-foreground">
+                    {t('chart.volumeDistributionTitle')}
+                </h3>
+                <Button
+                    variant="outline"
+                    size="icon"
+                    className="absolute right-0 top-1/2 -translate-y-1/2"
+                    onClick={downloadImage}
+                >
+                    <Download className="h-4 w-4" />
+                    <span className="sr-only">{t('chart.downloadImage')}</span>
+                </Button>
+            </div>
+            <div ref={chartRef}>
+                <ResponsiveContainer width="100%" height={chartHeight}>
+                    <BarChart data={data} margin={{ top: 20, right: 30, left: 20, bottom: 20 }}>
                     <defs>
                         <linearGradient id="volumeGradient" x1="0" y1="0" x2="0" y2="1">
                             <stop offset="0%" stopColor="#60a5fa" />
@@ -113,21 +159,23 @@ export function VolumeDistributionChart({ data, weightedApy }: VolumeDistributio
                         radius={[4, 4, 0, 0]}
                         barSize={isMobile ? 20 : 40}
                     >
-                        <LabelList
-                            dataKey="volume"
-                            position="top"
-                            fill="#e5e7eb"
-                            fontSize={12}
-                            formatter={(value: ReactNode) => {
-                                const numValue = typeof value === 'number' ? value : Number(value);
-                                if (numValue >= 1000000) {
-                                    return `${(numValue / 1000000).toFixed(1)}M`;
-                                } else if (numValue >= 1000) {
-                                    return `${(numValue / 1000).toFixed(1)}K`;
-                                }
-                                return numValue.toString();
-                            }}
-                        />
+                        {!isMobile && (
+                            <LabelList
+                                dataKey="volume"
+                                position="top"
+                                fill="#e5e7eb"
+                                fontSize={12}
+                                formatter={(value: ReactNode) => {
+                                    const numValue = typeof value === 'number' ? value : Number(value);
+                                    if (numValue >= 1000000) {
+                                        return `${(numValue / 1000000).toFixed(1)}M`;
+                                    } else if (numValue >= 1000) {
+                                        return `${(numValue / 1000).toFixed(1)}K`;
+                                    }
+                                    return numValue.toString();
+                                }}
+                            />
+                        )}
                     </Bar>
                     <ReferenceLine
                         x={effectiveWeightedApy}
@@ -142,8 +190,9 @@ export function VolumeDistributionChart({ data, weightedApy }: VolumeDistributio
                             fontWeight: 'bold',
                         }}
                     />
-                </BarChart>
-            </ResponsiveContainer>
+                    </BarChart>
+                </ResponsiveContainer>
+            </div>
         </div>
     );
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -12,18 +12,19 @@
     "menu": "Menu",
     "run": "Run"
   },
-  "chart": {
-    "noDataAvailable": "No data available for chart",
-    "yAxisLeft": "YT Price",
-    "yAxisRight": "Points earned",
-    "fairValueCurve": "Fair Value Curve of YT",
-    "underlyingCoin": "underlying coin",
-    "maximizePointsHint": "Buy when YT price is below the fair value curve to maximize points",
-    "maturity": "Maturity:",
-    "volumeDistributionTitle": "Volume distribution by implied APY",
-    "impliedApy": "Implied APY (%)",
-    "volume": "Volume (USD)"
-  },
+    "chart": {
+        "noDataAvailable": "No data available for chart",
+        "yAxisLeft": "YT Price",
+        "yAxisRight": "Points earned",
+        "fairValueCurve": "Fair Value Curve of YT",
+        "underlyingCoin": "underlying coin",
+        "maximizePointsHint": "Buy when YT price is below the fair value curve to maximize points",
+        "maturity": "Maturity:",
+        "volumeDistributionTitle": "Volume distribution by implied APY",
+        "impliedApy": "Implied APY (%)",
+        "volume": "Volume (USD)",
+        "downloadImage": "Download image"
+    },
   "main": {
     "chain": "Chain",
     "market": "Market",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -12,18 +12,19 @@
     "menu": "菜单",
     "run": "运行"
   },
-  "chart": {
-    "noDataAvailable": "暂无图表数据",
-    "yAxisLeft": "YT 价格",
-    "yAxisRight": "获得的积分",
-    "fairValueCurve": "YT 公平价值曲线",
-    "underlyingCoin": "底层代币",
-    "maximizePointsHint": "在 YT 价格低于公平价值曲线时购买以最大化积分",
-    "maturity": "到期时间：",
-    "volumeDistributionTitle": "不同隐含年化收益率的成交量分布",
-    "impliedApy": "隐含年化收益率 (%)",
-    "volume": "成交量 (USD)"
-  },
+    "chart": {
+        "noDataAvailable": "暂无图表数据",
+        "yAxisLeft": "YT 价格",
+        "yAxisRight": "获得的积分",
+        "fairValueCurve": "YT 公平价值曲线",
+        "underlyingCoin": "底层代币",
+        "maximizePointsHint": "在 YT 价格低于公平价值曲线时购买以最大化积分",
+        "maturity": "到期时间：",
+        "volumeDistributionTitle": "不同隐含年化收益率的成交量分布",
+        "impliedApy": "隐含年化收益率 (%)",
+        "volume": "成交量 (USD)",
+        "downloadImage": "下载图片"
+    },
   "main": {
     "chain": "链",
     "market": "市场",


### PR DESCRIPTION
## Summary
- Pass precomputed volume-weighted APY to the volume distribution chart
- Use provided value for reference line to align chart with summary section

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any and other lint errors in existing files)
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b86a49fff8832e95454940a422ee77