### PR TITLE
fix: improve chart export

### DIFF
--- a/src/components/VolumeDistributionChart.tsx
+++ b/src/components/VolumeDistributionChart.tsx
@@ -37,28 +37,47 @@ export function VolumeDistributionChart({ data, weightedApy }: VolumeDistributio
         if (!chartRef.current) return;
         const svg = chartRef.current.querySelector('svg');
         if (!svg) return;
+
+        const exportWidth = 1280;
+        const exportHeight = 720; // 16:9
+        const scale = Math.max(2, window.devicePixelRatio || 1);
+
+        const { width: svgWidth, height: svgHeight } = svg.getBoundingClientRect();
+        const clonedSvg = svg.cloneNode(true) as SVGSVGElement;
+        clonedSvg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+        clonedSvg.setAttribute('width', String(exportWidth));
+        clonedSvg.setAttribute('height', String(exportHeight));
+        clonedSvg.setAttribute('viewBox', `0 0 ${svgWidth} ${svgHeight}`);
+
         const serializer = new XMLSerializer();
-        const svgData = serializer.serializeToString(svg);
+        const svgData = serializer.serializeToString(clonedSvg);
         const blob = new Blob([svgData], { type: 'image/svg+xml;charset=utf-8' });
         const url = URL.createObjectURL(blob);
         const image = new Image();
-        const width = 1280;
-        const height = 720;
         image.onload = () => {
             const canvas = document.createElement('canvas');
-            canvas.width = width;
-            canvas.height = height;
+            canvas.width = exportWidth * scale;
+            canvas.height = exportHeight * scale;
             const ctx = canvas.getContext('2d');
-            if (ctx) {
-                ctx.fillStyle = '#ffffff';
-                ctx.fillRect(0, 0, width, height);
-                ctx.drawImage(image, 0, 0, width, height);
-                const link = document.createElement('a');
-                link.download = 'volume-distribution.png';
-                link.href = canvas.toDataURL('image/png');
-                link.click();
+            if (!ctx) {
+                URL.revokeObjectURL(url);
+                alert(t('chart.downloadFailed'));
+                return;
             }
+            ctx.scale(scale, scale);
+            const backgroundColor = getComputedStyle(chartRef.current!).backgroundColor || '#ffffff';
+            ctx.fillStyle = backgroundColor;
+            ctx.fillRect(0, 0, exportWidth, exportHeight);
+            ctx.drawImage(image, 0, 0, exportWidth, exportHeight);
+            const link = document.createElement('a');
+            link.download = 'volume-distribution.png';
+            link.href = canvas.toDataURL('image/png');
+            link.click();
             URL.revokeObjectURL(url);
+        };
+        image.onerror = () => {
+            URL.revokeObjectURL(url);
+            alert(t('chart.downloadFailed'));
         };
         image.src = url;
     };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -23,7 +23,8 @@
         "volumeDistributionTitle": "Volume distribution by implied APY",
         "impliedApy": "Implied APY (%)",
         "volume": "Volume (USD)",
-        "downloadImage": "Download image"
+        "downloadImage": "Download image",
+        "downloadFailed": "Failed to download image"
     },
   "main": {
     "chain": "Chain",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -23,7 +23,8 @@
         "volumeDistributionTitle": "不同隐含年化收益率的成交量分布",
         "impliedApy": "隐含年化收益率 (%)",
         "volume": "成交量 (USD)",
-        "downloadImage": "下载图片"
+        "downloadImage": "下载图片",
+        "downloadFailed": "下载图片失败"
     },
   "main": {
     "chain": "链",


### PR DESCRIPTION
## Summary
- render charts to 16:9 canvas with high DPI scaling and theme-colored background
- provide fallback alert on export failure and translate message

## Testing
- `npm run lint` (fails: Unexpected any etc.)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b86fed41b0832eb361c37b3882d47f