### PR TITLE
Remove chart download feature

### DIFF
--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -8,10 +8,7 @@ import {
     Legend,
     ResponsiveContainer
 } from 'recharts';
-import { useRef } from 'react';
-import { Download } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { Button } from '@/components/ui/button';
 import { useWindowSize } from '../hooks/use-window-size';
 
 export interface ChartData {
@@ -34,80 +31,6 @@ export function Chart({ data, marketName, underlyingAmount, chainName, maturityD
     const { width } = useWindowSize();
     const isMobile = width < 640;
     const chartHeight = isMobile ? Math.min(400, Math.max(200, width * 0.8)) : 400;
-    const chartRef = useRef<HTMLDivElement>(null);
-
-    const downloadImage = () => {
-        if (!chartRef.current) return;
-        const svg = chartRef.current.querySelector('svg');
-        if (!svg) return;
-
-        const exportWidth = 1280;
-        const exportHeight = 720; // 16:9 ratio
-        const scale = Math.max(2, window.devicePixelRatio || 1);
-
-        const { width: svgWidth, height: svgHeight } = svg.getBoundingClientRect();
-        const clonedSvg = svg.cloneNode(true) as SVGSVGElement;
-        clonedSvg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
-        clonedSvg.setAttribute('width', String(exportWidth));
-        clonedSvg.setAttribute('height', String(exportHeight));
-        clonedSvg.setAttribute('viewBox', `0 0 ${svgWidth} ${svgHeight}`);
-
-        const serializer = new XMLSerializer();
-        const svgData = serializer.serializeToString(clonedSvg);
-        const blob = new Blob([svgData], { type: 'image/svg+xml;charset=utf-8' });
-        const url = URL.createObjectURL(blob);
-
-        const image = new Image();
-        image.onload = () => {
-            const canvas = document.createElement('canvas');
-            canvas.width = exportWidth * scale;
-            canvas.height = exportHeight * scale;
-            const ctx = canvas.getContext('2d');
-            if (!ctx) {
-                URL.revokeObjectURL(url);
-                alert(t('chart.downloadFailed'));
-                return;
-            }
-            ctx.scale(scale, scale);
-            const backgroundColor = getComputedStyle(chartRef.current!).backgroundColor || '#ffffff';
-            ctx.fillStyle = backgroundColor;
-            ctx.fillRect(0, 0, exportWidth, exportHeight);
-            ctx.drawImage(image, 0, 0, exportWidth, exportHeight);
-
-            // Draw legend manually to ensure it's included
-            const legendItems = [
-                { color: '#3b82f6', label: t('chart.yAxisLeft') },
-                { color: '#f97316', label: t('chart.yAxisRight') },
-                { color: '#22c55e', label: t('chart.fairValueCurve') },
-            ];
-            const textColor = '#ffffff';
-            const fontSize = 14;
-            ctx.font = `${fontSize}px sans-serif`;
-            ctx.textBaseline = 'middle';
-            let x = (exportWidth -
-                legendItems.reduce((acc, item) => acc + ctx.measureText(item.label).width + 40, 0)
-            ) / 2;
-            const y = exportHeight - 20;
-            legendItems.forEach((item) => {
-                ctx.fillStyle = item.color;
-                ctx.fillRect(x, y - 6, 12, 12);
-                ctx.fillStyle = textColor;
-                ctx.fillText(item.label, x + 18, y);
-                x += ctx.measureText(item.label).width + 40;
-            });
-
-            const link = document.createElement('a');
-            link.download = 'chart.png';
-            link.href = canvas.toDataURL('image/png');
-            link.click();
-            URL.revokeObjectURL(url);
-        };
-        image.onerror = () => {
-            URL.revokeObjectURL(url);
-            alert(t('chart.downloadFailed'));
-        };
-        image.src = url;
-    };
     
     if (!data || data.length === 0) {
         return (
@@ -122,22 +45,11 @@ export function Chart({ data, marketName, underlyingAmount, chainName, maturityD
 
     return (
         <div className="w-full bg-card card-elevated rounded-lg p-6">
-            <div className="relative mb-6">
-                <h3 className="text-lg font-semibold text-center text-foreground">
-                    {marketName} on {chainName} [{underlyingAmount} {t('chart.underlyingCoin')}] {maturityDate ? `- ${t('chart.maturity')} ${maturityDate.toLocaleString()}` : ''}
-                </h3>
-                <Button
-                    variant="outline"
-                    size="icon"
-                    className="absolute right-0 top-1/2 -translate-y-1/2"
-                    onClick={downloadImage}
-                >
-                    <Download className="h-4 w-4" />
-                    <span className="sr-only">{t('chart.downloadImage')}</span>
-                </Button>
-            </div>
+            <h3 className="mb-6 text-lg font-semibold text-center text-foreground">
+                {marketName} on {chainName} [{underlyingAmount} {t('chart.underlyingCoin')}] {maturityDate ? `- ${t('chart.maturity')} ${maturityDate.toLocaleString()}` : ''}
+            </h3>
 
-            <div ref={chartRef}>
+            <div>
                 <ResponsiveContainer width="100%" height={chartHeight}>
                     <LineChart key={i18n.language} data={chartData} margin={{ top: 20, right: 30, left: 20, bottom: 20 }}>
                     <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />

--- a/src/components/VolumeDistributionChart.tsx
+++ b/src/components/VolumeDistributionChart.tsx
@@ -10,10 +10,7 @@ import {
     ReferenceLine,
 } from 'recharts';
 import type { ReactNode } from 'react';
-import { useRef } from 'react';
-import { Download } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { Button } from '@/components/ui/button';
 import { useWindowSize } from '../hooks/use-window-size';
 
 export interface VolumeDistributionData {
@@ -31,56 +28,6 @@ export function VolumeDistributionChart({ data, weightedApy }: VolumeDistributio
     const { width } = useWindowSize();
     const isMobile = width < 640;
     const chartHeight = isMobile ? Math.min(300, Math.max(200, width * 0.6)) : 300;
-    const chartRef = useRef<HTMLDivElement>(null);
-
-    const downloadImage = () => {
-        if (!chartRef.current) return;
-        const svg = chartRef.current.querySelector('svg');
-        if (!svg) return;
-
-        const exportWidth = 1280;
-        const exportHeight = 720; // 16:9
-        const scale = Math.max(2, window.devicePixelRatio || 1);
-
-        const { width: svgWidth, height: svgHeight } = svg.getBoundingClientRect();
-        const clonedSvg = svg.cloneNode(true) as SVGSVGElement;
-        clonedSvg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
-        clonedSvg.setAttribute('width', String(exportWidth));
-        clonedSvg.setAttribute('height', String(exportHeight));
-        clonedSvg.setAttribute('viewBox', `0 0 ${svgWidth} ${svgHeight}`);
-
-        const serializer = new XMLSerializer();
-        const svgData = serializer.serializeToString(clonedSvg);
-        const blob = new Blob([svgData], { type: 'image/svg+xml;charset=utf-8' });
-        const url = URL.createObjectURL(blob);
-        const image = new Image();
-        image.onload = () => {
-            const canvas = document.createElement('canvas');
-            canvas.width = exportWidth * scale;
-            canvas.height = exportHeight * scale;
-            const ctx = canvas.getContext('2d');
-            if (!ctx) {
-                URL.revokeObjectURL(url);
-                alert(t('chart.downloadFailed'));
-                return;
-            }
-            ctx.scale(scale, scale);
-            const backgroundColor = getComputedStyle(chartRef.current!).backgroundColor || '#ffffff';
-            ctx.fillStyle = backgroundColor;
-            ctx.fillRect(0, 0, exportWidth, exportHeight);
-            ctx.drawImage(image, 0, 0, exportWidth, exportHeight);
-            const link = document.createElement('a');
-            link.download = 'volume-distribution.png';
-            link.href = canvas.toDataURL('image/png');
-            link.click();
-            URL.revokeObjectURL(url);
-        };
-        image.onerror = () => {
-            URL.revokeObjectURL(url);
-            alert(t('chart.downloadFailed'));
-        };
-        image.src = url;
-    };
 
     if (!data || data.length === 0) {
         return (
@@ -103,21 +50,10 @@ export function VolumeDistributionChart({ data, weightedApy }: VolumeDistributio
 
     return (
         <div className="w-full bg-card card-elevated rounded-lg p-6">
-            <div className="relative mb-6">
-                <h3 className="text-lg font-semibold text-center text-foreground">
-                    {t('chart.volumeDistributionTitle')}
-                </h3>
-                <Button
-                    variant="outline"
-                    size="icon"
-                    className="absolute right-0 top-1/2 -translate-y-1/2"
-                    onClick={downloadImage}
-                >
-                    <Download className="h-4 w-4" />
-                    <span className="sr-only">{t('chart.downloadImage')}</span>
-                </Button>
-            </div>
-            <div ref={chartRef}>
+            <h3 className="mb-6 text-lg font-semibold text-center text-foreground">
+                {t('chart.volumeDistributionTitle')}
+            </h3>
+            <div>
                 <ResponsiveContainer width="100%" height={chartHeight}>
                     <BarChart data={data} margin={{ top: 20, right: 30, left: 20, bottom: 20 }}>
                     <defs>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -22,9 +22,7 @@
         "maturity": "Maturity:",
         "volumeDistributionTitle": "Volume distribution by implied APY",
         "impliedApy": "Implied APY (%)",
-        "volume": "Volume (USD)",
-        "downloadImage": "Download image",
-        "downloadFailed": "Failed to download image"
+        "volume": "Volume (USD)"
     },
   "main": {
     "chain": "Chain",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -22,9 +22,7 @@
         "maturity": "到期时间：",
         "volumeDistributionTitle": "不同隐含年化收益率的成交量分布",
         "impliedApy": "隐含年化收益率 (%)",
-        "volume": "成交量 (USD)",
-        "downloadImage": "下载图片",
-        "downloadFailed": "下载图片失败"
+        "volume": "成交量 (USD)"
     },
   "main": {
     "chain": "链",


### PR DESCRIPTION
## Summary
- Remove chart image download functionality and associated UI elements
- Drop unused translation strings related to chart downloading

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars, fast refresh export issues)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b872de15bc832e80348d804c40367c