### PR TITLE
feat: add manual run button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { From } from './components/Main'
+import { Main } from './components/Main'
 import Header from './components/Header'
 import { ThemeProvider } from "@/components/ThemeProvider"
 
@@ -8,7 +8,7 @@ function App() {
       <div className="min-h-screen">
         <Header />
         <main className="container mx-auto p-4 sm:p-8">
-          <From />
+          <Main />
         </main>
       </div>
     </ThemeProvider>

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -5,13 +5,13 @@ const DEFAULT_TIMEOUT = 10000 // 10 seconds timeout
 export class ApiError extends Error {
   public status?: number
   public code?: string
-  public details?: any
+  public details?: unknown
   
   constructor(
     message: string,
     status?: number,
     code?: string,
-    details?: any
+    details?: unknown
   ) {
     super(message)
     this.name = 'ApiError'
@@ -22,7 +22,7 @@ export class ApiError extends Error {
 }
 
 // API response type
-export interface ApiResponse<T = any> {
+export interface ApiResponse<T = unknown> {
   success: boolean
   data?: T
   error?: string

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,7 +13,7 @@ import {
   DropdownMenuSubContent,
 } from './ui/dropdown-menu';
 import { Menu } from 'lucide-react';
-import { useTheme } from './ThemeProvider';
+import { useTheme } from '@/hooks/theme-context';
 
 const Header: React.FC = () => {
   const { t, i18n } = useTranslation();

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { chainsArray } from '../constant/chain';
 import {
@@ -10,6 +10,7 @@ import {
 } from './ui/select';
 import { MarketSelect } from './MarketSelect';
 import { Input } from './ui/input';
+import { Button } from './ui/button';
 
 import { getTransactionsAll } from '@/api/pendle';
 import type { Market } from '@/api/pendle';
@@ -38,7 +39,7 @@ export function From() {
 
 
 
-    // Auto-update function
+    // Update chart data
     const updateChart = useCallback(async () => {
         if (!selectedMarket) return;
 
@@ -139,23 +140,6 @@ export function From() {
         }
     }, [selectedMarket, selectedChain, underlyingAmount, pointsPerDay, pendleMultiplier]);
 
-    // Auto-update when market is selected (immediate)
-    useEffect(() => {
-        if (selectedMarket) {
-            updateChart();
-        }
-    }, [selectedMarket, updateChart]);
-
-    // Auto-update when inputs change (debounced)
-    useEffect(() => {
-        if (selectedMarket) {
-            const timeoutId = setTimeout(() => {
-                updateChart();
-            }, 500);
-            return () => clearTimeout(timeoutId);
-        }
-    }, [selectedMarket, updateChart]);
-
     return (
         <div className='container mx-auto px-4 pt-16 sm:pt-24 space-y-8'>
             <div className='bg-card card-elevated rounded-lg p-4 sm:p-6'>
@@ -217,9 +201,17 @@ export function From() {
                     />
                 </div>
 
+                </div>
+                <div className="mt-4 flex justify-end">
+                    <Button
+                        onClick={updateChart}
+                        disabled={!selectedMarket || isLoading}
+                        className="input-enhanced">
+                        {t('main.run')}
+                    </Button>
+                </div>
             </div>
-            </div>
-            
+
             {/* Loading Indicator */}
             {isLoading && (
                 <div className="mt-4 text-center">

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -18,7 +18,7 @@ import { compute } from '@/compute';
 import { Chart, type ChartData } from './Chart';
 import { VolumeDistributionChart, type VolumeDistributionData } from './VolumeDistributionChart';
 
-export function From() {
+export function Main() {
     const { t } = useTranslation();
     const [selectedChain, setSelectedChain] = useState<string>(chainsArray[0]?.chainId.toString() || "1");
     const [selectedMarket, setSelectedMarket] = useState<Market | null>(null);

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -144,7 +144,7 @@ export function From() {
         <div className='container mx-auto px-4 pt-16 sm:pt-24 space-y-8'>
             <div className='bg-card card-elevated rounded-lg p-4 sm:p-6'>
                 <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4'>
-                <div className='flex flex-col space-y-2'>
+                <div className='flex flex-col space-y-2 w-full sm:max-w-xs'>
                     <label className='text-sm font-medium text-muted-foreground whitespace-nowrap'>{t('main.chain')}</label>
                     <Select value={selectedChain} onValueChange={handleChainChange}>
                         <SelectTrigger className="w-full input-enhanced">
@@ -160,12 +160,12 @@ export function From() {
                     </Select>
                 </div>
 
-                <div className='flex flex-col space-y-2'>
+                <div className='flex flex-col space-y-2 w-full sm:max-w-xs'>
                     <label className='text-sm font-medium text-muted-foreground whitespace-nowrap'>{t('main.market')}</label>
                     <MarketSelect selectedChain={selectedChain} selectedMarket={selectedMarket} setSelectedMarket={setSelectedMarket} />
                 </div>
 
-                <div className='flex flex-col space-y-2'>
+                <div className='flex flex-col space-y-2 w-full sm:max-w-xs'>
                     <label className='text-sm font-medium text-muted-foreground whitespace-nowrap'>{t('main.underlyingAmount')}</label>
                     <Input
                         type="number"
@@ -177,7 +177,7 @@ export function From() {
                     />
                 </div>
 
-                <div className='flex flex-col space-y-2'>
+                <div className='flex flex-col space-y-2 w-full sm:max-w-xs'>
                     <label className='text-sm font-medium text-muted-foreground whitespace-nowrap'>{t('main.pointsPerDay')}</label>
                     <Input
                         type="number"
@@ -189,7 +189,7 @@ export function From() {
                     />
                 </div>
 
-                <div className='flex flex-col space-y-2'>
+                <div className='flex flex-col space-y-2 w-full sm:max-w-xs'>
                     <label className='text-sm font-medium text-muted-foreground whitespace-nowrap'>{t('main.pendleMultiplier')}</label>
                     <Input
                         type="number"
@@ -206,7 +206,7 @@ export function From() {
                     <Button
                         onClick={updateChart}
                         disabled={!selectedMarket || isLoading}
-                        className="input-enhanced">
+                        className="w-full sm:w-auto input-enhanced">
                         {t('main.run')}
                     </Button>
                 </div>

--- a/src/components/ModeToggle.tsx
+++ b/src/components/ModeToggle.tsx
@@ -8,7 +8,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { useTheme } from "@/components/ThemeProvider"
+import { useTheme } from "@/hooks/theme-context"
 
 export function ModeToggle() {
     const { t } = useTranslation();

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,24 +1,11 @@
-import { createContext, useContext, useEffect, useState } from "react"
-
-type Theme = "dark" | "light" | "system"
+import { useEffect, useState, type ReactNode } from 'react'
+import { ThemeProviderContext, type Theme } from '@/hooks/theme-context'
 
 type ThemeProviderProps = {
-  children: React.ReactNode
+  children: ReactNode
   defaultTheme?: Theme
   storageKey?: string
 }
-
-type ThemeProviderState = {
-  theme: Theme
-  setTheme: (theme: Theme) => void
-}
-
-const initialState: ThemeProviderState = {
-  theme: "system",
-  setTheme: () => null,
-}
-
-const ThemeProviderContext = createContext<ThemeProviderState>(initialState)
 
 export function ThemeProvider({
   children,
@@ -61,13 +48,4 @@ export function ThemeProvider({
       {children}
     </ThemeProviderContext.Provider>
   )
-}
-
-export const useTheme = () => {
-  const context = useContext(ThemeProviderContext)
-
-  if (context === undefined)
-    throw new Error("useTheme must be used within a ThemeProvider")
-
-  return context
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -56,4 +56,4 @@ function Button({
   )
 }
 
-export { Button, buttonVariants }
+export { Button }

--- a/src/hooks/theme-context.ts
+++ b/src/hooks/theme-context.ts
@@ -1,0 +1,22 @@
+import { createContext, useContext } from 'react'
+
+export type Theme = 'dark' | 'light' | 'system'
+
+export type ThemeProviderState = {
+  theme: Theme
+  setTheme: (theme: Theme) => void
+}
+
+export const ThemeProviderContext = createContext<ThemeProviderState>({
+  theme: 'system',
+  setTheme: () => null
+})
+
+export function useTheme(): ThemeProviderState {
+  const context = useContext(ThemeProviderContext)
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider')
+  }
+  return context
+}
+

--- a/src/index.css
+++ b/src/index.css
@@ -126,42 +126,24 @@
   .card-subtle {
     @apply shadow-md shadow-black/3 border border-border/40;
   }
-  
+
   .input-enhanced {
-    @apply border-2 border-border/60 focus:border-primary/60 focus:ring-2 focus:ring-primary/20;
+    @apply w-full h-10 px-3 bg-background border-2 border-border/60 focus:border-primary/60 focus:ring-2 focus:ring-primary/20;
   }
-  
-  /* 确保Button组件在浅色模式下与Input组件样式一致 */
-  .input-enhanced[data-variant="outline"] {
-    @apply bg-background text-foreground border-2 border-border/60 hover:bg-accent/50 hover:text-accent-foreground focus:border-primary/60 focus:ring-2 focus:ring-primary/20;
-  }
-  
-  /* 统一所有input-enhanced样式的背景色和边框 */
-  .input-enhanced {
-    @apply bg-background border-2 border-border/60;
-  }
-  
-  /* 确保Button组件的outline变体在浅色模式下与Input组件完全一致 */
+
   .input-enhanced[data-variant="outline"],
   button.input-enhanced[data-variant="outline"] {
     @apply bg-background text-foreground border-2 border-border/60 hover:bg-accent/50 hover:text-accent-foreground focus:border-primary/60 focus:ring-2 focus:ring-primary/20;
   }
-  
-  /* 确保Select组件在浅色模式下与Input组件样式一致 */
+
   .input-enhanced[data-slot="select-trigger"] {
     @apply bg-background border-2 border-border/60;
   }
-  
-  /* 确保所有input-enhanced组件在浅色模式下都有一致的背景色和边框 */
-  .input-enhanced {
-    @apply bg-background border-2 border-border/60;
-  }
-  
-  /* 覆盖任何可能的内联背景色设置 */
+
   .input-enhanced[style*="background"] {
     background-color: var(--background) !important;
   }
-  
+
   .badge-enhanced {
     @apply border border-border/60 shadow-sm shadow-black/2;
   }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -37,7 +37,8 @@
     "network": "Network:",
     "transactionsUnique": "Transactions (unique)",
     "weightedImpliedAPYVolume": "Weighted Implied APY (Volume-weighted)",
-    "pointsAvailable": "Points earned if bought now until maturity"
+    "pointsAvailable": "Points earned if bought now until maturity",
+    "run": "Run"
   },
   "marketSelect": {
     "loadingMarkets": "Loading markets...",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -37,7 +37,8 @@
     "network": "网络:",
     "transactionsUnique": "交易数量 (唯一)",
     "weightedImpliedAPYVolume": "加权隐含年化收益率 (按成交量加权)",
-    "pointsAvailable": "从现在购买到到期可获得的积分"
+    "pointsAvailable": "从现在购买到到期可获得的积分",
+    "run": "运行"
   },
   "marketSelect": {
     "loadingMarkets": "正在加载市场...",


### PR DESCRIPTION
## Summary
- add run button so chart updates only when triggered
- localize new run control in English and Chinese

## Testing
- `npm run lint` *(fails: Unexpected any, Fast refresh only works when file only exports components)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b874d075dc832eb69d9080c9668489