### PR TITLE
Fix header width and improve responsive layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,8 @@ function App() {
     <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
       <div className="min-h-screen">
         <Header />
-        <main className="container mx-auto p-4 sm:p-8">
+        {/* Removed extra container to align header and content widths */}
+        <main className="py-4 sm:py-8">
           <Main />
         </main>
       </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -31,9 +31,9 @@ const Header: React.FC = () => {
   const nextLanguage = i18n.language === 'zh' ? 'en' : 'zh';
 
   return (
-    <header className="fixed top-0 left-0 right-0 z-50 border-b bg-background/80 backdrop-blur">
+    <header className="fixed top-0 left-0 right-0 z-50 border-b bg-gradient-to-r from-background/90 to-background/60 backdrop-blur shadow-sm">
       <div className="container mx-auto px-4 py-2 sm:px-6 sm:py-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between">
           {/* Left side - Title and badges */}
           <div className="flex items-center space-x-4">
             {/* Pendle logo */}
@@ -53,7 +53,8 @@ const Header: React.FC = () => {
 
               {/* Badges */}
               <div className="flex items-center space-x-2 mt-1">
-                <span className="px-2 py-1 bg-muted badge-enhanced text-muted-foreground text-xs rounded-full">
+                {/* Hide badge on smaller screens to prevent overflow */}
+                <span className="hidden md:inline-flex px-2 py-1 bg-muted badge-enhanced text-muted-foreground text-xs rounded-full">
                   {t('header.secureBackend')}
                 </span>
               </div>

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -141,8 +141,9 @@ export function Main() {
     }, [selectedMarket, selectedChain, underlyingAmount, pointsPerDay, pendleMultiplier]);
 
     return (
-        <div className='container mx-auto px-4 pt-16 sm:pt-24 space-y-8'>
-            <div className='bg-card card-elevated rounded-lg p-4 sm:p-6'>
+        <div className='container mx-auto px-4 sm:px-6 pt-16 sm:pt-24 space-y-8'>
+            {/* Align padding with header for consistent widths */}
+            <div className='bg-card card-elevated rounded-xl p-4 sm:p-6 bg-gradient-to-br from-card to-card/80'>
                 <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4'>
                 <div className='flex flex-col space-y-2 w-full sm:max-w-xs'>
                     <label className='text-sm font-medium text-muted-foreground whitespace-nowrap'>{t('main.chain')}</label>
@@ -225,7 +226,7 @@ export function Main() {
             {/* Market Summary */}
             {selectedMarket && (
                 <div className="mt-8">
-                    <div className="bg-card card-elevated rounded-lg p-4 sm:p-6">
+                    <div className="bg-card card-elevated rounded-xl p-4 sm:p-6 bg-gradient-to-br from-card to-card/80">
                         {/* Header Section */}
                         <div className="flex flex-wrap gap-3 mb-6">
                             <div className="bg-muted badge-enhanced px-3 py-1 rounded-full text-sm font-medium">

--- a/src/index.css
+++ b/src/index.css
@@ -42,23 +42,23 @@
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(0.98 0.005 247.858);
+  --background: oklch(0.965 0.015 247.858);
   --foreground: oklch(0.129 0.042 264.695);
-  --card: oklch(0.95 0.008 247.896);
+  --card: oklch(0.98 0.008 247.896);
   --card-foreground: oklch(0.129 0.042 264.695);
-  --popover: oklch(0.95 0.008 247.896);
+  --popover: oklch(0.98 0.008 247.896);
   --popover-foreground: oklch(0.129 0.042 264.695);
   --primary: oklch(0.208 0.042 265.755);
   --primary-foreground: oklch(0.984 0.003 247.858);
-  --secondary: oklch(0.92 0.01 247.896);
+  --secondary: oklch(0.93 0.01 247.896);
   --secondary-foreground: oklch(0.208 0.042 265.755);
-  --muted: oklch(0.92 0.01 247.896);
+  --muted: oklch(0.93 0.01 247.896);
   --muted-foreground: oklch(0.554 0.046 257.417);
-  --accent: oklch(0.92 0.01 247.896);
+  --accent: oklch(0.93 0.01 247.896);
   --accent-foreground: oklch(0.208 0.042 265.755);
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.85 0.015 255.508);
-  --input: oklch(0.85 0.015 255.508);
+  --border: oklch(0.86 0.015 255.508);
+  --input: oklch(0.86 0.015 255.508);
   --ring: oklch(0.704 0.04 256.788);
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);


### PR DESCRIPTION
## Summary
- align header and content widths by removing nested container and matching padding
- improve header responsiveness by enabling wrapping and hiding badge on small screens
- soften light mode background and add gradients for a more polished UI

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b87a9792c0832ebe36006e9540382d