### PR TITLE
refactor: align layout and soften light theme

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -32,10 +32,10 @@ const Header: React.FC = () => {
 
   return (
     <header className="fixed top-0 left-0 right-0 z-50 border-b bg-gradient-to-r from-background/90 to-background/60 backdrop-blur shadow-sm">
-      <div className="container mx-auto px-4 py-2 sm:px-6 sm:py-4">
-        <div className="flex flex-wrap items-center justify-between">
+      <div className="container mx-auto max-w-4xl px-4 py-2 sm:px-6 sm:py-4">
+        <div className="flex flex-wrap items-center justify-between gap-4">
           {/* Left side - Title and badges */}
-          <div className="flex items-center space-x-4">
+          <div className="flex items-center gap-4">
             {/* Pendle logo */}
             <div className="w-12 h-12 rounded-full overflow-hidden">
               <img
@@ -62,8 +62,8 @@ const Header: React.FC = () => {
           </div>
 
           {/* Right side - Action buttons */}
-          <div className="flex items-center space-x-4">
-            <div className="hidden sm:flex items-center space-x-4">
+          <div className="flex items-center gap-2 sm:gap-4">
+            <div className="hidden sm:flex items-center gap-2 sm:gap-4">
               {/* GitHub button */}
               <Button
                 variant="outline"

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -141,9 +141,9 @@ export function Main() {
     }, [selectedMarket, selectedChain, underlyingAmount, pointsPerDay, pendleMultiplier]);
 
     return (
-        <div className='container mx-auto px-4 sm:px-6 pt-16 sm:pt-24 space-y-8'>
-            {/* Align padding with header for consistent widths */}
-            <div className='bg-card card-elevated rounded-xl p-4 sm:p-6 bg-gradient-to-br from-card to-card/80'>
+          <div className='container mx-auto max-w-4xl px-4 sm:px-6 pt-20 sm:pt-24 space-y-10'>
+              {/* Align padding with header for consistent widths */}
+              <div className='bg-card card-elevated rounded-xl p-4 sm:p-6 bg-gradient-to-br from-card to-card/80'>
                 <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4'>
                 <div className='flex flex-col space-y-2 w-full sm:max-w-xs'>
                     <label className='text-sm font-medium text-muted-foreground whitespace-nowrap'>{t('main.chain')}</label>

--- a/src/index.css
+++ b/src/index.css
@@ -42,37 +42,37 @@
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(0.965 0.015 247.858);
+  --background: oklch(0.94 0.015 247.858);
   --foreground: oklch(0.129 0.042 264.695);
-  --card: oklch(0.98 0.008 247.896);
+  --card: oklch(0.96 0.008 247.896);
   --card-foreground: oklch(0.129 0.042 264.695);
-  --popover: oklch(0.98 0.008 247.896);
+  --popover: oklch(0.96 0.008 247.896);
   --popover-foreground: oklch(0.129 0.042 264.695);
   --primary: oklch(0.208 0.042 265.755);
   --primary-foreground: oklch(0.984 0.003 247.858);
-  --secondary: oklch(0.93 0.01 247.896);
+  --secondary: oklch(0.92 0.01 247.896);
   --secondary-foreground: oklch(0.208 0.042 265.755);
-  --muted: oklch(0.93 0.01 247.896);
+  --muted: oklch(0.92 0.01 247.896);
   --muted-foreground: oklch(0.554 0.046 257.417);
-  --accent: oklch(0.93 0.01 247.896);
+  --accent: oklch(0.92 0.01 247.896);
   --accent-foreground: oklch(0.208 0.042 265.755);
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.86 0.015 255.508);
-  --input: oklch(0.86 0.015 255.508);
-  --ring: oklch(0.704 0.04 256.788);
+  --border: oklch(0.83 0.015 255.508);
+  --input: oklch(0.83 0.015 255.508);
+  --ring: oklch(0.68 0.04 256.788);
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.95 0.008 247.896);
+  --sidebar: oklch(0.93 0.008 247.896);
   --sidebar-foreground: oklch(0.129 0.042 264.695);
   --sidebar-primary: oklch(0.208 0.042 265.755);
   --sidebar-primary-foreground: oklch(0.984 0.003 247.858);
-  --sidebar-accent: oklch(0.92 0.01 247.896);
+  --sidebar-accent: oklch(0.9 0.01 247.896);
   --sidebar-accent-foreground: oklch(0.208 0.042 265.755);
-  --sidebar-border: oklch(0.85 0.015 255.508);
-  --sidebar-ring: oklch(0.704 0.04 256.788);
+  --sidebar-border: oklch(0.8 0.015 255.508);
+  --sidebar-ring: oklch(0.68 0.04 256.788);
 }
 
 .dark {


### PR DESCRIPTION
## Summary
- align header width with content and refine spacing
- tune main container spacing for cleaner layout
- darken light mode colors for comfort

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b87f6b3250832ebdbce329ee9d5d20