### PR TITLE
Align header and main content widths

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,8 +7,7 @@ function App() {
     <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
       <div className="min-h-screen">
         <Header />
-        {/* Removed extra container to align header and content widths */}
-        <main className="py-4 sm:py-8">
+        <main>
           <Main />
         </main>
       </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -32,7 +32,7 @@ const Header: React.FC = () => {
 
   return (
     <header className="sticky top-0 z-50 border-b bg-gradient-to-r from-background/90 to-background/60 backdrop-blur shadow-sm">
-      <div className="mx-auto max-w-screen-lg px-4 py-2 sm:px-6 sm:py-4">
+      <div className="mx-auto max-w-screen-xl px-4 py-2 sm:px-6 sm:py-4">
         <div className="flex flex-wrap md:flex-nowrap items-center justify-between gap-4">
           {/* Left side - Title and badges */}
           <div className="flex items-center gap-4 min-w-0">

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -141,7 +141,7 @@ export function Main() {
     }, [selectedMarket, selectedChain, underlyingAmount, pointsPerDay, pendleMultiplier]);
 
     return (
-          <div className='mx-auto max-w-screen-lg px-4 sm:px-6 pt-20 sm:pt-24 space-y-10'>
+          <div className='mx-auto max-w-screen-xl px-4 sm:px-6 pt-6 sm:pt-8 space-y-10'>
               {/* Align padding with header for consistent widths */}
               <div className='bg-card card-elevated rounded-xl p-4 sm:p-6 bg-gradient-to-br from-card to-card/80'>
                 <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4'>


### PR DESCRIPTION
## Summary
- widen page containers to `max-w-screen-xl`
- reduce header-main spacing by trimming redundant padding

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b886b26d28832e839d4f0042ae4e77