### PR TITLE
Fix header and main layout alignment

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -31,8 +31,8 @@ const Header: React.FC = () => {
   const nextLanguage = i18n.language === 'zh' ? 'en' : 'zh';
 
   return (
-    <header className="sticky top-0 z-50 border-b bg-gradient-to-r from-background/90 to-background/60 backdrop-blur shadow-sm">
-      <div className="mx-auto max-w-screen-xl px-4 py-2 sm:px-6 sm:py-4">
+    <header className="sticky top-0 z-50 border-b bg-gradient-to-r from-background/90 to-background/60 backdrop-blur shadow-sm mx-auto w-full max-w-screen-xl">
+      <div className="px-4 py-2 sm:px-6 sm:py-3">
         <div className="flex flex-wrap md:flex-nowrap items-center justify-between gap-4">
           {/* Left side - Title and badges */}
           <div className="flex items-center gap-4 min-w-0">

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -141,11 +141,11 @@ export function Main() {
     }, [selectedMarket, selectedChain, underlyingAmount, pointsPerDay, pendleMultiplier]);
 
     return (
-          <div className='mx-auto max-w-screen-xl px-4 sm:px-6 pt-6 sm:pt-8 space-y-10'>
+          <div className='mx-auto w-full max-w-screen-xl px-4 sm:px-6 pt-4 sm:pt-6 space-y-8'>
               {/* Align padding with header for consistent widths */}
               <div className='bg-card card-elevated rounded-xl p-4 sm:p-6 bg-gradient-to-br from-card to-card/80'>
                 <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4'>
-                <div className='flex flex-col space-y-2 w-full sm:max-w-xs'>
+                <div className='flex flex-col space-y-2 w-full'>
                     <label className='text-sm font-medium text-muted-foreground whitespace-nowrap'>{t('main.chain')}</label>
                     <Select value={selectedChain} onValueChange={handleChainChange}>
                         <SelectTrigger className="w-full input-enhanced">
@@ -161,12 +161,12 @@ export function Main() {
                     </Select>
                 </div>
 
-                <div className='flex flex-col space-y-2 w-full sm:max-w-xs'>
+                <div className='flex flex-col space-y-2 w-full'>
                     <label className='text-sm font-medium text-muted-foreground whitespace-nowrap'>{t('main.market')}</label>
                     <MarketSelect selectedChain={selectedChain} selectedMarket={selectedMarket} setSelectedMarket={setSelectedMarket} />
                 </div>
 
-                <div className='flex flex-col space-y-2 w-full sm:max-w-xs'>
+                <div className='flex flex-col space-y-2 w-full'>
                     <label className='text-sm font-medium text-muted-foreground whitespace-nowrap'>{t('main.underlyingAmount')}</label>
                     <Input
                         type="number"
@@ -178,7 +178,7 @@ export function Main() {
                     />
                 </div>
 
-                <div className='flex flex-col space-y-2 w-full sm:max-w-xs'>
+                <div className='flex flex-col space-y-2 w-full'>
                     <label className='text-sm font-medium text-muted-foreground whitespace-nowrap'>{t('main.pointsPerDay')}</label>
                     <Input
                         type="number"
@@ -190,7 +190,7 @@ export function Main() {
                     />
                 </div>
 
-                <div className='flex flex-col space-y-2 w-full sm:max-w-xs'>
+                <div className='flex flex-col space-y-2 w-full'>
                     <label className='text-sm font-medium text-muted-foreground whitespace-nowrap'>{t('main.pendleMultiplier')}</label>
                     <Input
                         type="number"


### PR DESCRIPTION
## Summary
- Align header width with main container and tighten padding for a cleaner top section
- Allow main input grid to fully span the container for better responsive behavior

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b888276714832eab5a962671fffcaa