### PR TITLE
fix: compact header alignment

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -34,7 +34,7 @@ const Header: React.FC = () => {
     <header className="sticky top-0 z-50 border-b bg-gradient-to-r from-background/90 to-background/60 backdrop-blur shadow-sm">
       {/* Centered container to align with main content */}
       <div className="mx-auto w-full max-w-screen-xl px-4 py-2 sm:px-6 sm:py-3">
-        <div className="flex flex-wrap md:flex-nowrap items-center justify-between gap-4">
+        <div className="flex flex-wrap items-center justify-between gap-4">
           {/* Left side - Title and badges */}
           <div className="flex items-center gap-4 min-w-0">
             {/* Pendle logo */}
@@ -63,8 +63,8 @@ const Header: React.FC = () => {
           </div>
 
           {/* Right side - Action buttons */}
-          <div className="flex flex-wrap md:flex-nowrap items-center gap-2 sm:gap-4 min-w-0">
-            <div className="hidden md:flex items-center gap-2 md:gap-4 min-w-0">
+          <div className="flex flex-wrap items-center gap-2 sm:gap-4 min-w-0">
+            <div className="hidden lg:flex items-center gap-2 lg:gap-4 min-w-0">
               {/* GitHub button */}
               <Button
                 variant="outline"
@@ -85,7 +85,7 @@ const Header: React.FC = () => {
                 <Button
                   variant="outline"
                   size="icon"
-                  className="md:hidden input-enhanced"
+                  className="lg:hidden input-enhanced"
                 >
                   <Menu className="w-5 h-5" />
                   <span className="sr-only">{t('header.menu')}</span>

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -17,7 +17,7 @@ const LanguageSwitcher: React.FC = () => {
     <Button
       variant="outline"
       onClick={toggleLanguage}
-      className="flex items-center space-x-2 w-24 input-enhanced"
+      className="flex items-center space-x-2 input-enhanced whitespace-nowrap"
     >
       <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />


### PR DESCRIPTION
## Summary
- prevent header actions from overflowing content width
- make language switcher width dynamic for tighter layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8903c945c832e90da3fcf8d77c4a7