### PR TITLE
Align header with content boundaries using shared container

### DIFF
--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import clsx from 'clsx';
+
+type ContainerProps = React.HTMLAttributes<HTMLDivElement>;
+
+export const Container: React.FC<ContainerProps> = ({ className, ...props }) => (
+  <div
+    className={clsx('mx-auto w-full max-w-screen-xl px-4 sm:px-6', className)}
+    {...props}
+  />
+);
+
+export default Container;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -14,6 +14,7 @@ import {
 } from './ui/dropdown-menu';
 import { Menu } from 'lucide-react';
 import { useTheme } from '@/hooks/theme-context';
+import Container from './Container';
 
 const Header: React.FC = () => {
   const { t, i18n } = useTranslation();
@@ -33,7 +34,7 @@ const Header: React.FC = () => {
   return (
     <header className="sticky top-0 z-50 border-b bg-gradient-to-r from-background/90 to-background/60 backdrop-blur shadow-sm">
       {/* Centered container to align with main content */}
-      <div className="mx-auto w-full max-w-screen-xl px-4 py-2 sm:px-6 sm:py-3">
+      <Container className="py-2 sm:py-3">
         <div className="flex flex-wrap items-center justify-between gap-4">
           {/* Left side - Title and badges */}
           <div className="flex items-center gap-4 min-w-0">
@@ -118,7 +119,7 @@ const Header: React.FC = () => {
             </DropdownMenu>
           </div>
         </div>
-      </div>
+      </Container>
     </header>
   );
 };

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -1,3 +1,4 @@
+
 import { useState, useCallback, Suspense, lazy } from 'react';
 import { useTranslation } from 'react-i18next';
 import { chainsArray } from '../constant/chain';
@@ -11,6 +12,7 @@ import {
 import { MarketSelect } from './MarketSelect';
 import { Input } from './ui/input';
 import { Button } from './ui/button';
+import Container from './Container';
 
 import { getTransactionsAll } from '@/api/pendle';
 import type { Market } from '@/api/pendle';
@@ -144,7 +146,7 @@ export function Main() {
     }, [selectedMarket, selectedChain, underlyingAmount, pointsPerDay, pendleMultiplier]);
 
     return (
-          <div className='mx-auto w-full max-w-screen-xl px-4 sm:px-6 pt-4 sm:pt-6 space-y-8'>
+          <Container className='pt-4 sm:pt-6 space-y-8'>
               {/* Align padding with header for consistent widths */}
               <div className='bg-card card-elevated rounded-xl p-4 sm:p-6 bg-gradient-to-br from-card to-card/80'>
                 <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4'>
@@ -294,6 +296,6 @@ export function Main() {
                     </Suspense>
                 </div>
             )}
-        </div>
+          </Container>
     );
 }


### PR DESCRIPTION
## Summary
- add a reusable `Container` component with shared max-width and padding
- wrap header and main content in the new container to keep their edges aligned

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b89384f5b8832e8c44ab31d3f2c28e