### PR TITLE
fix: align header actions with content width

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -70,7 +70,7 @@ const Header: React.FC = () => {
               <Button
                 variant="outline"
                 onClick={handleGitHubClick}
-                className="flex items-center space-x-2 input-enhanced truncate"
+                className="flex items-center space-x-2 input-enhanced w-auto truncate"
               >
                 <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
                   <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
@@ -86,7 +86,7 @@ const Header: React.FC = () => {
                 <Button
                   variant="outline"
                   size="icon"
-                  className="lg:hidden input-enhanced"
+                  className="lg:hidden input-enhanced w-auto"
                 >
                   <Menu className="w-5 h-5" />
                   <span className="sr-only">{t('header.menu')}</span>

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -17,7 +17,7 @@ const LanguageSwitcher: React.FC = () => {
     <Button
       variant="outline"
       onClick={toggleLanguage}
-      className="flex items-center space-x-2 input-enhanced whitespace-nowrap"
+      className="flex items-center space-x-2 input-enhanced w-auto whitespace-nowrap"
     >
       <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />

--- a/src/components/ModeToggle.tsx
+++ b/src/components/ModeToggle.tsx
@@ -17,7 +17,7 @@ export function ModeToggle() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="icon" className="input-enhanced">
+        <Button variant="outline" size="icon" className="input-enhanced w-auto">
           <Sun className="h-[1.2rem] w-[1.2rem] scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
           <Moon className="absolute h-[1.2rem] w-[1.2rem] scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
                           <span className="sr-only">{t('modeToggle.toggleTheme')}</span>


### PR DESCRIPTION
## Summary
- fix header overflow by constraining GitHub, language, theme, and menu buttons to auto width

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b89652a618832e9b20174ca514da2c